### PR TITLE
IPv6 support with tests

### DIFF
--- a/tailutils.go
+++ b/tailutils.go
@@ -5,6 +5,11 @@ import (
 	"net"
 )
 
+var (
+	TailscaleIP4CIDR = "100.64.0.0/10"
+	TailscaleIP6CIDR = "fd7a:115c:a1e0::/48"
+)
+
 // Network is an interface that abstracts the network operations used in tailutils.
 type Network interface {
 	ParseCIDR(s string) (*net.IP, *net.IPNet, error)
@@ -38,7 +43,7 @@ func GetTailscaleIP() (string, error) {
 
 func getTailscaleIP(netImpl Network) (string, error) {
 	// Define the Tailscale IP range
-	_, tsNet, err := netImpl.ParseCIDR("100.64.0.0/10")
+	_, tsNet, err := netImpl.ParseCIDR(TailscaleIP4CIDR)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse Tailscale IP range: %v", err)
 	}
@@ -92,6 +97,73 @@ func HasTailscaleIP() (bool, error) {
 
 func hasTailscaleIP(netImpl Network) (bool, error) {
 	_, err := getTailscaleIP(netImpl)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// GetTailscaleIP6 returns the IPv6 address of the Tailscale interface.
+func GetTailscaleIP6() (string, error) {
+	return getTailscaleIP6(DefaultNetwork)
+}
+
+func getTailscaleIP6(netImpl Network) (string, error) {
+	// Define the Tailscale IPv6 range
+	_, tsNet, err := netImpl.ParseCIDR(TailscaleIP6CIDR)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse Tailscale IPv6 range: %v", err)
+	}
+
+	// Get the list of network interfaces
+	ifaces, err := netImpl.Interfaces()
+	if err != nil {
+		return "", fmt.Errorf("failed to get network interfaces: %v", err)
+	}
+
+	// Find the Tailscale interface
+	for _, iface := range ifaces {
+		// Skip interfaces that are down or are loopback interfaces
+		if (iface.Flags&net.FlagUp == 0) || (iface.Flags&net.FlagLoopback != 0) {
+			continue
+		}
+
+		// Get all addresses associated with the interface
+		addrs, err := netImpl.Addrs(iface)
+		if err != nil {
+			return "", fmt.Errorf("failed to get interface addresses: %v", err)
+		}
+
+		// Check if any of the addresses belong to the Tailscale IPv6 range
+		for _, addr := range addrs {
+			// Check if the address is an IPNet
+			ipNet, ok := addr.(*net.IPNet)
+			if !ok {
+				continue
+			}
+
+			// Consider only IPv6 addresses
+			if ipNet.IP.To4() != nil {
+				continue
+			}
+
+			// Check if the address is within the Tailscale IPv6 network
+			if tsNet.Contains(ipNet.IP) {
+				return ipNet.IP.String(), nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("tailscale IPv6 interface not found")
+}
+
+// HasTailscaleIP6 returns true if the machine has a Tailscale IPv6 interface.
+func HasTailscaleIP6() (bool, error) {
+	return hasTailscaleIP6(DefaultNetwork)
+}
+
+func hasTailscaleIP6(netImpl Network) (bool, error) {
+	_, err := getTailscaleIP6(netImpl)
 	if err != nil {
 		return false, err
 	}

--- a/tailutils_test.go
+++ b/tailutils_test.go
@@ -294,3 +294,268 @@ func TestHasTailscaleIP_GetTailscaleIPError(t *testing.T) {
 	// Ensure all expectations were met
 	mockNet.AssertExpectations(t)
 }
+
+// TestGetTailscaleIP6_Success tests the successful retrieval of a Tailscale IPv6 address.
+func TestGetTailscaleIP6_Success(t *testing.T) {
+	mockNet := new(MockNetwork)
+
+	// Mock ParseCIDR for IPv6
+	tsCIDR := "fd7a:115c:a1e0::/48"
+	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
+	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
+
+	// Mock Interfaces
+	ifaces := []net.Interface{
+		{
+			Name:  "eth0",
+			Flags: net.FlagUp,
+		},
+		{
+			Name:  "tailscale0",
+			Flags: net.FlagUp,
+		},
+	}
+	mockNet.On("Interfaces").Return(ifaces, nil)
+
+	// Mock Addrs for eth0 (non-Tailscale IPv6)
+	ethIP := net.ParseIP("2001:db8::1")
+	ethAddr := &net.IPNet{
+		IP:   ethIP,
+		Mask: net.CIDRMask(64, 128),
+	}
+	mockNet.On("Addrs", ifaces[0]).Return([]net.Addr{ethAddr}, nil)
+
+	// Mock Addrs for tailscale0 (Tailscale IPv6)
+	tailscaleIP := net.ParseIP("fd7a:115c:a1e0::1")
+	tailscaleAddr := &net.IPNet{
+		IP:   tailscaleIP,
+		Mask: net.CIDRMask(48, 128),
+	}
+	mockNet.On("Addrs", ifaces[1]).Return([]net.Addr{tailscaleAddr}, nil)
+
+	// Execute the function
+	ipStr, err := getTailscaleIP6(mockNet)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.Equal(t, "fd7a:115c:a1e0::1", ipStr)
+
+	// Ensure all expectations were met
+	mockNet.AssertExpectations(t)
+}
+
+// TestGetTailscaleIP6_NoTailscaleInterface tests the scenario where no Tailscale IPv6 interface is found.
+func TestGetTailscaleIP6_NoTailscaleInterface(t *testing.T) {
+	mockNet := new(MockNetwork)
+
+	// Mock ParseCIDR for IPv6
+	tsCIDR := "fd7a:115c:a1e0::/48"
+	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
+	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
+
+	// Mock Interfaces without a Tailscale interface
+	ifaces := []net.Interface{
+		{
+			Name:  "eth0",
+			Flags: net.FlagUp,
+		},
+		{
+			Name:  "lo",
+			Flags: net.FlagUp | net.FlagLoopback,
+		},
+	}
+	mockNet.On("Interfaces").Return(ifaces, nil)
+
+	// Mock Addrs for eth0 (non-Tailscale IPv6)
+	ethIP := net.ParseIP("2001:db8::1")
+	ethAddr := &net.IPNet{
+		IP:   ethIP,
+		Mask: net.CIDRMask(64, 128),
+	}
+	mockNet.On("Addrs", ifaces[0]).Return([]net.Addr{ethAddr}, nil)
+
+	// Since tailscale0 is not present, no need to mock its Addrs
+
+	// Execute the function
+	ipStr, err := getTailscaleIP6(mockNet)
+
+	// Assertions
+	assert.Error(t, err)
+	assert.Equal(t, "", ipStr)
+	assert.EqualError(t, err, "tailscale IPv6 interface not found")
+
+	// Ensure all expectations were met
+	mockNet.AssertExpectations(t)
+}
+
+// TestGetTailscaleIP6_ParseCIDRError tests the scenario where ParseCIDR returns an error.
+func TestGetTailscaleIP6_ParseCIDRError(t *testing.T) {
+	mockNet := new(MockNetwork)
+
+	// Mock ParseCIDR to return an error when called with "fd7a:115c:a1e0::/48"
+	tsCIDR := "fd7a:115c:a1e0::/48"
+	mockNet.On("ParseCIDR", tsCIDR).Return((*net.IP)(nil), (*net.IPNet)(nil), errors.New("invalid CIDR"))
+
+	// Execute the function
+	ipStr, err := getTailscaleIP6(mockNet)
+
+	// Assertions
+	assert.Error(t, err)
+	assert.Equal(t, "", ipStr)
+	assert.Contains(t, err.Error(), "failed to parse Tailscale IPv6 range")
+
+	// Ensure all expectations were met
+	mockNet.AssertExpectations(t)
+}
+
+// TestGetTailscaleIP6_InterfacesError tests the scenario where retrieving interfaces returns an error.
+func TestGetTailscaleIP6_InterfacesError(t *testing.T) {
+	mockNet := new(MockNetwork)
+
+	// Mock ParseCIDR for IPv6
+	tsCIDR := "fd7a:115c:a1e0::/48"
+	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
+	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
+
+	// Mock Interfaces to return an error
+	mockNet.On("Interfaces").Return(nil, errors.New("interface error"))
+
+	// Execute the function
+	ipStr, err := getTailscaleIP6(mockNet)
+
+	// Assertions
+	assert.Error(t, err)
+	assert.Equal(t, "", ipStr)
+	assert.Contains(t, err.Error(), "failed to get network interfaces")
+
+	// Ensure all expectations were met
+	mockNet.AssertExpectations(t)
+}
+
+// TestGetTailscaleIP6_AddrsError tests the scenario where retrieving addresses for an interface returns an error.
+func TestGetTailscaleIP6_AddrsError(t *testing.T) {
+	mockNet := new(MockNetwork)
+
+	// Mock ParseCIDR for IPv6
+	tsCIDR := "fd7a:115c:a1e0::/48"
+	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
+	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
+
+	// Mock Interfaces with tailscale0
+	ifaces := []net.Interface{
+		{
+			Name:  "tailscale0",
+			Flags: net.FlagUp,
+		},
+	}
+	mockNet.On("Interfaces").Return(ifaces, nil)
+
+	// Mock Addrs to return an error for tailscale0
+	mockNet.On("Addrs", ifaces[0]).Return(nil, errors.New("addrs error"))
+
+	// Execute the function
+	ipStr, err := getTailscaleIP6(mockNet)
+
+	// Assertions
+	assert.Error(t, err)
+	assert.Equal(t, "", ipStr)
+	assert.Contains(t, err.Error(), "failed to get interface addresses")
+
+	// Ensure all expectations were met
+	mockNet.AssertExpectations(t)
+}
+
+// TestHasTailscaleIP6_Exists tests that HasTailscaleIP6 returns true when a Tailscale IPv6 interface exists.
+func TestHasTailscaleIP6_Exists(t *testing.T) {
+	mockNet := new(MockNetwork)
+
+	// Mock ParseCIDR for IPv6
+	tsCIDR := "fd7a:115c:a1e0::/48"
+	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
+	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
+
+	// Mock Interfaces with tailscale0
+	ifaces := []net.Interface{
+		{
+			Name:  "tailscale0",
+			Flags: net.FlagUp,
+		},
+	}
+	mockNet.On("Interfaces").Return(ifaces, nil)
+
+	// Mock Addrs for tailscale0 (Tailscale IPv6)
+	tailscaleIP := net.ParseIP("fd7a:115c:a1e0::1")
+	tailscaleAddr := &net.IPNet{
+		IP:   tailscaleIP,
+		Mask: net.CIDRMask(48, 128),
+	}
+	mockNet.On("Addrs", ifaces[0]).Return([]net.Addr{tailscaleAddr}, nil)
+
+	// Execute the function
+	exists, err := hasTailscaleIP6(mockNet)
+
+	// Assertions
+	assert.NoError(t, err)
+	assert.True(t, exists)
+
+	// Ensure all expectations were met
+	mockNet.AssertExpectations(t)
+}
+
+// TestHasTailscaleIP6_DoesNotExist tests that HasTailscaleIP6 returns false when no Tailscale IPv6 interface exists.
+func TestHasTailscaleIP6_DoesNotExist(t *testing.T) {
+	mockNet := new(MockNetwork)
+
+	// Mock ParseCIDR for IPv6
+	tsCIDR := "fd7a:115c:a1e0::/48"
+	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
+	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
+
+	// Mock Interfaces without a Tailscale interface
+	ifaces := []net.Interface{
+		{
+			Name:  "eth0",
+			Flags: net.FlagUp,
+		},
+	}
+	mockNet.On("Interfaces").Return(ifaces, nil)
+
+	// Mock Addrs for eth0 (non-Tailscale IPv6)
+	ethIP := net.ParseIP("2001:db8::1")
+	ethAddr := &net.IPNet{
+		IP:   ethIP,
+		Mask: net.CIDRMask(64, 128),
+	}
+	mockNet.On("Addrs", ifaces[0]).Return([]net.Addr{ethAddr}, nil)
+
+	// Execute the function
+	exists, err := hasTailscaleIP6(mockNet)
+
+	// Assertions
+	assert.Error(t, err)
+	assert.False(t, exists)
+	assert.EqualError(t, err, "tailscale IPv6 interface not found")
+
+	// Ensure all expectations were met
+	mockNet.AssertExpectations(t)
+}
+
+// TestHasTailscaleIP6_GetTailscaleIP6Error tests that HasTailscaleIP6 handles errors from getTailscaleIP6 correctly.
+func TestHasTailscaleIP6_GetTailscaleIP6Error(t *testing.T) {
+	mockNet := new(MockNetwork)
+
+	// Mock ParseCIDR to return an error when called with "fd7a:115c:a1e0::/48"
+	tsCIDR := "fd7a:115c:a1e0::/48"
+	mockNet.On("ParseCIDR", tsCIDR).Return((*net.IP)(nil), (*net.IPNet)(nil), errors.New("parse CIDR error"))
+
+	// Execute the function
+	exists, err := hasTailscaleIP6(mockNet)
+
+	// Assertions
+	assert.Error(t, err)
+	assert.False(t, exists)
+	assert.Contains(t, err.Error(), "failed to parse Tailscale IPv6 range")
+
+	// Ensure all expectations were met
+	mockNet.AssertExpectations(t)
+}


### PR DESCRIPTION
This adds support for IPv6 using Tailscale's [published IPv6 range](https://tailscale.com/kb/1033/ip-and-dns-addresses).