### PR TITLE
Get iname from ip

### DIFF
--- a/tailutils_test.go
+++ b/tailutils_test.go
@@ -4,558 +4,638 @@ import (
 	"errors"
 	"net"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 )
 
-// MockNetwork is a mock implementation of the Network interface.
+// MockNetwork is a mock implementation of the Network interface for testing purposes.
 type MockNetwork struct {
-	mock.Mock
+	ParseCIDRFunc  func(s string) (*net.IP, *net.IPNet, error)
+	ParseIPFunc    func(s string) (*net.IP, error)
+	InterfacesFunc func() ([]net.Interface, error)
+	AddrsFunc      func(iface net.Interface) ([]net.Addr, error)
 }
 
 func (m *MockNetwork) ParseCIDR(s string) (*net.IP, *net.IPNet, error) {
-	args := m.Called(s)
-	if args.Get(0) != nil {
-		return args.Get(0).(*net.IP), args.Get(1).(*net.IPNet), args.Error(2)
-	}
-	return nil, nil, args.Error(2)
+	return m.ParseCIDRFunc(s)
+}
+
+func (m *MockNetwork) ParseIP(s string) (*net.IP, error) {
+	return m.ParseIPFunc(s)
 }
 
 func (m *MockNetwork) Interfaces() ([]net.Interface, error) {
-	args := m.Called()
-	if args.Get(0) != nil {
-		return args.Get(0).([]net.Interface), args.Error(1)
-	}
-	return nil, args.Error(1)
+	return m.InterfacesFunc()
 }
 
 func (m *MockNetwork) Addrs(iface net.Interface) ([]net.Addr, error) {
-	args := m.Called(iface)
-	if args.Get(0) != nil {
-		return args.Get(0).([]net.Addr), args.Error(1)
-	}
-	return nil, args.Error(1)
+	return m.AddrsFunc(iface)
 }
 
-func TestGetTailscaleIP_Success(t *testing.T) {
-	mockNet := new(MockNetwork)
+// MockAddr is a mock implementation of net.Addr for testing purposes.
+type MockAddr struct{}
 
-	// Mock ParseCIDR
-	tsCIDR := "100.64.0.0/10"
-	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
-	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
+func (m *MockAddr) Network() string { return "mock" }
+func (m *MockAddr) String() string  { return "mockaddr" }
 
-	// Mock Interfaces
-	ifaces := []net.Interface{
-		{
-			Name:  "eth0",
-			Flags: net.FlagUp,
+func TestGetTailscaleIP(t *testing.T) {
+	// Simulate successful retrieval of Tailscale IP
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, err := net.ParseCIDR(s)
+			return &ip, ipNet, err
 		},
-		{
-			Name:  "tailscale0",
-			Flags: net.FlagUp,
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return []net.Interface{
+				{
+					Index: 1,
+					MTU:   1500,
+					Name:  "tailscale0",
+					Flags: net.FlagUp,
+				},
+			}, nil
 		},
-	}
-	mockNet.On("Interfaces").Return(ifaces, nil)
-
-	// Mock Addrs for eth0 (non-Tailscale IP)
-	ethIP := net.ParseIP("192.168.1.10")
-	ethAddr := &net.IPNet{
-		IP:   ethIP,
-		Mask: net.CIDRMask(24, 32),
-	}
-	mockNet.On("Addrs", ifaces[0]).Return([]net.Addr{ethAddr}, nil)
-
-	// Mock Addrs for tailscale0 (Tailscale IP)
-	tailscaleIP := net.ParseIP("100.64.0.1")
-	tailscaleAddr := &net.IPNet{
-		IP:   tailscaleIP,
-		Mask: net.CIDRMask(10, 32),
-	}
-	mockNet.On("Addrs", ifaces[1]).Return([]net.Addr{tailscaleAddr}, nil)
-
-	// Execute the function
-	ipStr, err := getTailscaleIP(mockNet)
-
-	// Assertions
-	assert.NoError(t, err)
-	assert.Equal(t, "100.64.0.1", ipStr)
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
-}
-
-func TestGetTailscaleIP_NoTailscaleInterface(t *testing.T) {
-	mockNet := new(MockNetwork)
-
-	// Mock ParseCIDR
-	tsCIDR := "100.64.0.0/10"
-	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
-	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
-
-	// Mock Interfaces
-	ifaces := []net.Interface{
-		{
-			Name:  "eth0",
-			Flags: net.FlagUp,
-		},
-		{
-			Name:  "lo",
-			Flags: net.FlagUp | net.FlagLoopback,
+		AddrsFunc: func(iface net.Interface) ([]net.Addr, error) {
+			if iface.Name == "tailscale0" {
+				ipNet := &net.IPNet{
+					IP:   net.IPv4(100, 64, 0, 1),
+					Mask: net.CIDRMask(10, 32),
+				}
+				return []net.Addr{ipNet}, nil
+			}
+			return nil, nil
 		},
 	}
-	mockNet.On("Interfaces").Return(ifaces, nil)
 
-	// Mock Addrs for eth0 (non-Tailscale IP)
-	ethIP := net.ParseIP("192.168.1.10")
-	ethAddr := &net.IPNet{
-		IP:   ethIP,
-		Mask: net.CIDRMask(24, 32),
+	ip, err := getTailscaleIP(mockNet)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
 	}
-	mockNet.On("Addrs", ifaces[0]).Return([]net.Addr{ethAddr}, nil)
-
-	// Since tailscale0 is not present, no need to mock its Addrs
-
-	// Execute the function
-	ipStr, err := getTailscaleIP(mockNet)
-
-	// Assertions
-	assert.Error(t, err)
-	assert.Equal(t, "", ipStr)
-	assert.EqualError(t, err, "tailscale interface not found")
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
+	expectedIP := "100.64.0.1"
+	if ip != expectedIP {
+		t.Errorf("Expected IP %s, got %s", expectedIP, ip)
+	}
 }
 
-func TestGetTailscaleIP_ParseCIDRError(t *testing.T) {
-	mockNet := new(MockNetwork)
-
-	// Mock ParseCIDR to return an error when called with "100.64.0.0/10"
-	tsCIDR := "100.64.0.0/10"
-	mockNet.On("ParseCIDR", tsCIDR).Return((*net.IP)(nil), (*net.IPNet)(nil), errors.New("invalid CIDR"))
-
-	// Execute the function
-	ipStr, err := getTailscaleIP(mockNet)
-
-	// Assertions
-	assert.Error(t, err)
-	assert.Equal(t, "", ipStr)
-	assert.Contains(t, err.Error(), "failed to parse Tailscale IP range")
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
-}
-
-func TestGetTailscaleIP_InterfacesError(t *testing.T) {
-	mockNet := new(MockNetwork)
-
-	// Mock ParseCIDR
-	tsCIDR := "100.64.0.0/10"
-	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
-	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
-
-	// Mock Interfaces to return an error
-	mockNet.On("Interfaces").Return(nil, errors.New("interface error"))
-
-	// Execute the function
-	ipStr, err := getTailscaleIP(mockNet)
-
-	// Assertions
-	assert.Error(t, err)
-	assert.Equal(t, "", ipStr)
-	assert.Contains(t, err.Error(), "failed to get network interfaces")
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
-}
-
-func TestGetTailscaleIP_AddrsError(t *testing.T) {
-	mockNet := new(MockNetwork)
-
-	// Mock ParseCIDR
-	tsCIDR := "100.64.0.0/10"
-	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
-	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
-
-	// Mock Interfaces
-	ifaces := []net.Interface{
-		{
-			Name:  "tailscale0",
-			Flags: net.FlagUp,
+func TestGetTailscaleIP_ParseCIDR_Error(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			return nil, nil, errors.New("ParseCIDR error")
 		},
 	}
-	mockNet.On("Interfaces").Return(ifaces, nil)
 
-	// Mock Addrs to return an error for tailscale0
-	mockNet.On("Addrs", ifaces[0]).Return(nil, errors.New("addrs error"))
-
-	// Execute the function
-	ipStr, err := getTailscaleIP(mockNet)
-
-	// Assertions
-	assert.Error(t, err)
-	assert.Equal(t, "", ipStr)
-	assert.Contains(t, err.Error(), "failed to get interface addresses")
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
+	ip, err := getTailscaleIP(mockNet)
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	if ip != "" {
+		t.Errorf("Expected empty IP, got %s", ip)
+	}
 }
 
-func TestHasTailscaleIP_Exists(t *testing.T) {
-	mockNet := new(MockNetwork)
-
-	// Mock ParseCIDR
-	tsCIDR := "100.64.0.0/10"
-	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
-	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
-
-	// Mock Interfaces
-	ifaces := []net.Interface{
-		{
-			Name:  "tailscale0",
-			Flags: net.FlagUp,
+func TestGetTailscaleIP_Interfaces_Error(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, _ := net.ParseCIDR(s)
+			return &ip, ipNet, nil
+		},
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return nil, errors.New("Interfaces error")
 		},
 	}
-	mockNet.On("Interfaces").Return(ifaces, nil)
 
-	// Mock Addrs for tailscale0
-	tailscaleIP := net.ParseIP("100.64.0.1")
-	tailscaleAddr := &net.IPNet{
-		IP:   tailscaleIP,
-		Mask: net.CIDRMask(10, 32),
+	ip, err := getTailscaleIP(mockNet)
+	if err == nil {
+		t.Errorf("Expected error, got nil")
 	}
-	mockNet.On("Addrs", ifaces[0]).Return([]net.Addr{tailscaleAddr}, nil)
-
-	// Execute the function
-	exists, err := hasTailscaleIP(mockNet)
-
-	// Assertions
-	assert.NoError(t, err)
-	assert.True(t, exists)
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
+	if ip != "" {
+		t.Errorf("Expected empty IP, got %s", ip)
+	}
 }
 
-func TestHasTailscaleIP_DoesNotExist(t *testing.T) {
-	mockNet := new(MockNetwork)
-
-	// Mock ParseCIDR
-	tsCIDR := "100.64.0.0/10"
-	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
-	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
-
-	// Mock Interfaces
-	ifaces := []net.Interface{
-		{
-			Name:  "eth0",
-			Flags: net.FlagUp,
+func TestGetTailscaleIP_NoInterfaces(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, _ := net.ParseCIDR(s)
+			return &ip, ipNet, nil
+		},
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return []net.Interface{
+				{
+					Index: 1,
+					MTU:   1500,
+					Name:  "lo",
+					Flags: net.FlagLoopback,
+				},
+			}, nil
 		},
 	}
-	mockNet.On("Interfaces").Return(ifaces, nil)
 
-	// Mock Addrs for eth0 (non-Tailscale IP)
-	ethIP := net.ParseIP("192.168.1.10")
-	ethAddr := &net.IPNet{
-		IP:   ethIP,
-		Mask: net.CIDRMask(24, 32),
+	ip, err := getTailscaleIP(mockNet)
+	if err == nil || err.Error() != "tailscale interface not found" {
+		t.Errorf("Expected 'tailscale interface not found' error, got %v", err)
 	}
-	mockNet.On("Addrs", ifaces[0]).Return([]net.Addr{ethAddr}, nil)
-
-	// Execute the function
-	exists, err := hasTailscaleIP(mockNet)
-
-	// Assertions
-	assert.Error(t, err)
-	assert.False(t, exists)
-	assert.EqualError(t, err, "tailscale interface not found")
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
+	if ip != "" {
+		t.Errorf("Expected empty IP, got %s", ip)
+	}
 }
 
-func TestHasTailscaleIP_GetTailscaleIPError(t *testing.T) {
-	mockNet := new(MockNetwork)
-
-	// Mock ParseCIDR to return an error when called with "100.64.0.0/10"
-	tsCIDR := "100.64.0.0/10"
-	mockNet.On("ParseCIDR", tsCIDR).Return((*net.IP)(nil), (*net.IPNet)(nil), errors.New("parse CIDR error"))
-
-	// Execute the function
-	exists, err := hasTailscaleIP(mockNet)
-
-	// Assertions
-	assert.Error(t, err)
-	assert.False(t, exists)
-	assert.Contains(t, err.Error(), "failed to parse Tailscale IP range")
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
-}
-
-// TestGetTailscaleIP6_Success tests the successful retrieval of a Tailscale IPv6 address.
-func TestGetTailscaleIP6_Success(t *testing.T) {
-	mockNet := new(MockNetwork)
-
-	// Mock ParseCIDR for IPv6
-	tsCIDR := "fd7a:115c:a1e0::/48"
-	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
-	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
-
-	// Mock Interfaces
-	ifaces := []net.Interface{
-		{
-			Name:  "eth0",
-			Flags: net.FlagUp,
+func TestGetTailscaleIP_Addrs_Error(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, _ := net.ParseCIDR(s)
+			return &ip, ipNet, nil
 		},
-		{
-			Name:  "tailscale0",
-			Flags: net.FlagUp,
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return []net.Interface{
+				{
+					Index: 1,
+					MTU:   1500,
+					Name:  "eth0",
+					Flags: net.FlagUp,
+				},
+			}, nil
+		},
+		AddrsFunc: func(iface net.Interface) ([]net.Addr, error) {
+			return nil, errors.New("Addrs error")
 		},
 	}
-	mockNet.On("Interfaces").Return(ifaces, nil)
 
-	// Mock Addrs for eth0 (non-Tailscale IPv6)
-	ethIP := net.ParseIP("2001:db8::1")
-	ethAddr := &net.IPNet{
-		IP:   ethIP,
-		Mask: net.CIDRMask(64, 128),
+	ip, err := getTailscaleIP(mockNet)
+	if err == nil || err.Error() != "failed to get interface addresses: Addrs error" {
+		t.Errorf("Expected 'Addrs error', got %v", err)
 	}
-	mockNet.On("Addrs", ifaces[0]).Return([]net.Addr{ethAddr}, nil)
-
-	// Mock Addrs for tailscale0 (Tailscale IPv6)
-	tailscaleIP := net.ParseIP("fd7a:115c:a1e0::1")
-	tailscaleAddr := &net.IPNet{
-		IP:   tailscaleIP,
-		Mask: net.CIDRMask(48, 128),
+	if ip != "" {
+		t.Errorf("Expected empty IP, got %s", ip)
 	}
-	mockNet.On("Addrs", ifaces[1]).Return([]net.Addr{tailscaleAddr}, nil)
-
-	// Execute the function
-	ipStr, err := getTailscaleIP6(mockNet)
-
-	// Assertions
-	assert.NoError(t, err)
-	assert.Equal(t, "fd7a:115c:a1e0::1", ipStr)
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
 }
 
-// TestGetTailscaleIP6_NoTailscaleInterface tests the scenario where no Tailscale IPv6 interface is found.
-func TestGetTailscaleIP6_NoTailscaleInterface(t *testing.T) {
-	mockNet := new(MockNetwork)
-
-	// Mock ParseCIDR for IPv6
-	tsCIDR := "fd7a:115c:a1e0::/48"
-	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
-	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
-
-	// Mock Interfaces without a Tailscale interface
-	ifaces := []net.Interface{
-		{
-			Name:  "eth0",
-			Flags: net.FlagUp,
+func TestGetTailscaleIP_NoMatchingIP(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, _ := net.ParseCIDR(s)
+			return &ip, ipNet, nil
 		},
-		{
-			Name:  "lo",
-			Flags: net.FlagUp | net.FlagLoopback,
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return []net.Interface{
+				{
+					Index: 1,
+					MTU:   1500,
+					Name:  "eth0",
+					Flags: net.FlagUp,
+				},
+			}, nil
+		},
+		AddrsFunc: func(iface net.Interface) ([]net.Addr, error) {
+			ipNet := &net.IPNet{
+				IP:   net.IPv4(192, 168, 1, 1),
+				Mask: net.CIDRMask(24, 32),
+			}
+			return []net.Addr{ipNet}, nil
 		},
 	}
-	mockNet.On("Interfaces").Return(ifaces, nil)
 
-	// Mock Addrs for eth0 (non-Tailscale IPv6)
-	ethIP := net.ParseIP("2001:db8::1")
-	ethAddr := &net.IPNet{
-		IP:   ethIP,
-		Mask: net.CIDRMask(64, 128),
+	ip, err := getTailscaleIP(mockNet)
+	if err == nil || err.Error() != "tailscale interface not found" {
+		t.Errorf("Expected 'tailscale interface not found' error, got %v", err)
 	}
-	mockNet.On("Addrs", ifaces[0]).Return([]net.Addr{ethAddr}, nil)
-
-	// Since tailscale0 is not present, no need to mock its Addrs
-
-	// Execute the function
-	ipStr, err := getTailscaleIP6(mockNet)
-
-	// Assertions
-	assert.Error(t, err)
-	assert.Equal(t, "", ipStr)
-	assert.EqualError(t, err, "tailscale IPv6 interface not found")
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
+	if ip != "" {
+		t.Errorf("Expected empty IP, got %s", ip)
+	}
 }
 
-// TestGetTailscaleIP6_ParseCIDRError tests the scenario where ParseCIDR returns an error.
-func TestGetTailscaleIP6_ParseCIDRError(t *testing.T) {
-	mockNet := new(MockNetwork)
-
-	// Mock ParseCIDR to return an error when called with "fd7a:115c:a1e0::/48"
-	tsCIDR := "fd7a:115c:a1e0::/48"
-	mockNet.On("ParseCIDR", tsCIDR).Return((*net.IP)(nil), (*net.IPNet)(nil), errors.New("invalid CIDR"))
-
-	// Execute the function
-	ipStr, err := getTailscaleIP6(mockNet)
-
-	// Assertions
-	assert.Error(t, err)
-	assert.Equal(t, "", ipStr)
-	assert.Contains(t, err.Error(), "failed to parse Tailscale IPv6 range")
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
-}
-
-// TestGetTailscaleIP6_InterfacesError tests the scenario where retrieving interfaces returns an error.
-func TestGetTailscaleIP6_InterfacesError(t *testing.T) {
-	mockNet := new(MockNetwork)
-
-	// Mock ParseCIDR for IPv6
-	tsCIDR := "fd7a:115c:a1e0::/48"
-	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
-	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
-
-	// Mock Interfaces to return an error
-	mockNet.On("Interfaces").Return(nil, errors.New("interface error"))
-
-	// Execute the function
-	ipStr, err := getTailscaleIP6(mockNet)
-
-	// Assertions
-	assert.Error(t, err)
-	assert.Equal(t, "", ipStr)
-	assert.Contains(t, err.Error(), "failed to get network interfaces")
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
-}
-
-// TestGetTailscaleIP6_AddrsError tests the scenario where retrieving addresses for an interface returns an error.
-func TestGetTailscaleIP6_AddrsError(t *testing.T) {
-	mockNet := new(MockNetwork)
-
-	// Mock ParseCIDR for IPv6
-	tsCIDR := "fd7a:115c:a1e0::/48"
-	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
-	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
-
-	// Mock Interfaces with tailscale0
-	ifaces := []net.Interface{
-		{
-			Name:  "tailscale0",
-			Flags: net.FlagUp,
+func TestGetTailscaleIP_NonIPNetAddress(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, _ := net.ParseCIDR(s)
+			return &ip, ipNet, nil
+		},
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return []net.Interface{
+				{
+					Index: 1,
+					MTU:   1500,
+					Name:  "eth0",
+					Flags: net.FlagUp,
+				},
+			}, nil
+		},
+		AddrsFunc: func(iface net.Interface) ([]net.Addr, error) {
+			return []net.Addr{&MockAddr{}}, nil
 		},
 	}
-	mockNet.On("Interfaces").Return(ifaces, nil)
 
-	// Mock Addrs to return an error for tailscale0
-	mockNet.On("Addrs", ifaces[0]).Return(nil, errors.New("addrs error"))
-
-	// Execute the function
-	ipStr, err := getTailscaleIP6(mockNet)
-
-	// Assertions
-	assert.Error(t, err)
-	assert.Equal(t, "", ipStr)
-	assert.Contains(t, err.Error(), "failed to get interface addresses")
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
+	ip, err := getTailscaleIP(mockNet)
+	if err == nil || err.Error() != "tailscale interface not found" {
+		t.Errorf("Expected 'tailscale interface not found' error, got %v", err)
+	}
+	if ip != "" {
+		t.Errorf("Expected empty IP, got %s", ip)
+	}
 }
 
-// TestHasTailscaleIP6_Exists tests that HasTailscaleIP6 returns true when a Tailscale IPv6 interface exists.
-func TestHasTailscaleIP6_Exists(t *testing.T) {
-	mockNet := new(MockNetwork)
-
-	// Mock ParseCIDR for IPv6
-	tsCIDR := "fd7a:115c:a1e0::/48"
-	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
-	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
-
-	// Mock Interfaces with tailscale0
-	ifaces := []net.Interface{
-		{
-			Name:  "tailscale0",
-			Flags: net.FlagUp,
+func TestGetTailscaleIP_IPv6Address(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, _ := net.ParseCIDR(s)
+			return &ip, ipNet, nil
+		},
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return []net.Interface{
+				{
+					Index: 1,
+					MTU:   1500,
+					Name:  "eth0",
+					Flags: net.FlagUp,
+				},
+			}, nil
+		},
+		AddrsFunc: func(iface net.Interface) ([]net.Addr, error) {
+			ipNet := &net.IPNet{
+				IP:   net.ParseIP("fd7a:115c:a1e0::1"),
+				Mask: net.CIDRMask(48, 128),
+			}
+			return []net.Addr{ipNet}, nil
 		},
 	}
-	mockNet.On("Interfaces").Return(ifaces, nil)
 
-	// Mock Addrs for tailscale0 (Tailscale IPv6)
-	tailscaleIP := net.ParseIP("fd7a:115c:a1e0::1")
-	tailscaleAddr := &net.IPNet{
-		IP:   tailscaleIP,
-		Mask: net.CIDRMask(48, 128),
+	ip, err := getTailscaleIP(mockNet)
+	if err == nil || err.Error() != "tailscale interface not found" {
+		t.Errorf("Expected 'tailscale interface not found' error, got %v", err)
 	}
-	mockNet.On("Addrs", ifaces[0]).Return([]net.Addr{tailscaleAddr}, nil)
-
-	// Execute the function
-	exists, err := hasTailscaleIP6(mockNet)
-
-	// Assertions
-	assert.NoError(t, err)
-	assert.True(t, exists)
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
+	if ip != "" {
+		t.Errorf("Expected empty IP, got %s", ip)
+	}
 }
 
-// TestHasTailscaleIP6_DoesNotExist tests that HasTailscaleIP6 returns false when no Tailscale IPv6 interface exists.
-func TestHasTailscaleIP6_DoesNotExist(t *testing.T) {
-	mockNet := new(MockNetwork)
-
-	// Mock ParseCIDR for IPv6
-	tsCIDR := "fd7a:115c:a1e0::/48"
-	ip, ipNet, _ := net.ParseCIDR(tsCIDR)
-	mockNet.On("ParseCIDR", tsCIDR).Return(&ip, ipNet, nil)
-
-	// Mock Interfaces without a Tailscale interface
-	ifaces := []net.Interface{
-		{
-			Name:  "eth0",
-			Flags: net.FlagUp,
+func TestGetTailscaleIP6(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, err := net.ParseCIDR(s)
+			return &ip, ipNet, err
+		},
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return []net.Interface{
+				{
+					Index: 1,
+					MTU:   1500,
+					Name:  "tailscale0",
+					Flags: net.FlagUp,
+				},
+			}, nil
+		},
+		AddrsFunc: func(iface net.Interface) ([]net.Addr, error) {
+			if iface.Name == "tailscale0" {
+				ipNet := &net.IPNet{
+					IP:   net.ParseIP("fd7a:115c:a1e0::1"),
+					Mask: net.CIDRMask(48, 128),
+				}
+				return []net.Addr{ipNet}, nil
+			}
+			return nil, nil
 		},
 	}
-	mockNet.On("Interfaces").Return(ifaces, nil)
 
-	// Mock Addrs for eth0 (non-Tailscale IPv6)
-	ethIP := net.ParseIP("2001:db8::1")
-	ethAddr := &net.IPNet{
-		IP:   ethIP,
-		Mask: net.CIDRMask(64, 128),
+	ip, err := getTailscaleIP6(mockNet)
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
 	}
-	mockNet.On("Addrs", ifaces[0]).Return([]net.Addr{ethAddr}, nil)
-
-	// Execute the function
-	exists, err := hasTailscaleIP6(mockNet)
-
-	// Assertions
-	assert.Error(t, err)
-	assert.False(t, exists)
-	assert.EqualError(t, err, "tailscale IPv6 interface not found")
-
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
+	expectedIP := "fd7a:115c:a1e0::1"
+	if ip != expectedIP {
+		t.Errorf("Expected IP %s, got %s", expectedIP, ip)
+	}
 }
 
-// TestHasTailscaleIP6_GetTailscaleIP6Error tests that HasTailscaleIP6 handles errors from getTailscaleIP6 correctly.
-func TestHasTailscaleIP6_GetTailscaleIP6Error(t *testing.T) {
-	mockNet := new(MockNetwork)
+func TestHasTailscaleIP_BothIPv4IPv6(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, _ := net.ParseCIDR(s)
+			return &ip, ipNet, nil
+		},
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return []net.Interface{
+				{
+					Index: 1,
+					MTU:   1500,
+					Name:  "tailscale0",
+					Flags: net.FlagUp,
+				},
+			}, nil
+		},
+		AddrsFunc: func(iface net.Interface) ([]net.Addr, error) {
+			if iface.Name == "tailscale0" {
+				ipNetIPv4 := &net.IPNet{
+					IP:   net.IPv4(100, 64, 0, 1),
+					Mask: net.CIDRMask(10, 32),
+				}
+				ipNetIPv6 := &net.IPNet{
+					IP:   net.ParseIP("fd7a:115c:a1e0::1"),
+					Mask: net.CIDRMask(48, 128),
+				}
+				return []net.Addr{ipNetIPv4, ipNetIPv6}, nil
+			}
+			return nil, nil
+		},
+	}
 
-	// Mock ParseCIDR to return an error when called with "fd7a:115c:a1e0::/48"
-	tsCIDR := "fd7a:115c:a1e0::/48"
-	mockNet.On("ParseCIDR", tsCIDR).Return((*net.IP)(nil), (*net.IPNet)(nil), errors.New("parse CIDR error"))
+	oldDefaultNetwork := DefaultNetwork
+	DefaultNetwork = mockNet
+	defer func() {
+		DefaultNetwork = oldDefaultNetwork
+	}()
 
-	// Execute the function
-	exists, err := hasTailscaleIP6(mockNet)
+	hasIP, err := HasTailscaleIP()
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if !hasIP {
+		t.Errorf("Expected true, got false")
+	}
+}
 
-	// Assertions
-	assert.Error(t, err)
-	assert.False(t, exists)
-	assert.Contains(t, err.Error(), "failed to parse Tailscale IPv6 range")
+func TestGetInterfaceName_TailscaleIPv4(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, err := net.ParseCIDR(s)
+			return &ip, ipNet, err
+		},
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return []net.Interface{
+				{
+					Index: 1,
+					Name:  "tailscale0",
+					Flags: net.FlagUp,
+				},
+				{
+					Index: 2,
+					Name:  "eth0",
+					Flags: net.FlagUp,
+				},
+			}, nil
+		},
+		AddrsFunc: func(iface net.Interface) ([]net.Addr, error) {
+			if iface.Name == "tailscale0" {
+				return []net.Addr{
+					&net.IPNet{
+						IP:   net.IPv4(100, 64, 0, 1),
+						Mask: net.CIDRMask(10, 32),
+					},
+				}, nil
+			} else if iface.Name == "eth0" {
+				return []net.Addr{
+					&net.IPNet{
+						IP:   net.IPv4(192, 168, 1, 10),
+						Mask: net.CIDRMask(24, 32),
+					},
+				}, nil
+			}
+			return nil, nil
+		},
+	}
 
-	// Ensure all expectations were met
-	mockNet.AssertExpectations(t)
+	oldDefaultNetwork := DefaultNetwork
+	DefaultNetwork = mockNet
+	defer func() {
+		DefaultNetwork = oldDefaultNetwork
+	}()
+
+	ifaceName, err := GetInterfaceName("100.64.0.1")
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if ifaceName != "tailscale0" {
+		t.Errorf("Expected interface name tailscale0, got %s", ifaceName)
+	}
+}
+
+func TestGetInterfaceName_TailscaleIPv6(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, err := net.ParseCIDR(s)
+			return &ip, ipNet, err
+		},
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return []net.Interface{
+				{
+					Index: 1,
+					Name:  "tailscale0",
+					Flags: net.FlagUp,
+				},
+				{
+					Index: 2,
+					Name:  "eth0",
+					Flags: net.FlagUp,
+				},
+			}, nil
+		},
+		AddrsFunc: func(iface net.Interface) ([]net.Addr, error) {
+			if iface.Name == "tailscale0" {
+				return []net.Addr{
+					&net.IPNet{
+						IP:   net.ParseIP("fd7a:115c:a1e0::1"),
+						Mask: net.CIDRMask(48, 128),
+					},
+				}, nil
+			} else if iface.Name == "eth0" {
+				return []net.Addr{
+					&net.IPNet{
+						IP:   net.IPv4(192, 168, 1, 10),
+						Mask: net.CIDRMask(24, 32),
+					},
+				}, nil
+			}
+			return nil, nil
+		},
+	}
+
+	oldDefaultNetwork := DefaultNetwork
+	DefaultNetwork = mockNet
+	defer func() {
+		DefaultNetwork = oldDefaultNetwork
+	}()
+
+	ifaceName, err := GetInterfaceName("fd7a:115c:a1e0::1")
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if ifaceName != "tailscale0" {
+		t.Errorf("Expected interface name tailscale0, got %s", ifaceName)
+	}
+}
+
+func TestGetInterfaceName_IPNotInTailscaleRange(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, err := net.ParseCIDR(s)
+			return &ip, ipNet, err
+		},
+	}
+
+	oldDefaultNetwork := DefaultNetwork
+	DefaultNetwork = mockNet
+	defer func() {
+		DefaultNetwork = oldDefaultNetwork
+	}()
+
+	ip := "192.168.1.10"
+	_, err := GetInterfaceName(ip)
+	expectedErr := "IP address 192.168.1.10 is not within the Tailscale IP range"
+	if err == nil || err.Error() != expectedErr {
+		t.Errorf("Expected error '%s', got %v", expectedErr, err)
+	}
+}
+
+func TestGetInterfaceName_IPNotFound(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, err := net.ParseCIDR(s)
+			return &ip, ipNet, err
+		},
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return []net.Interface{
+				{
+					Index: 1,
+					Name:  "tailscale0",
+					Flags: net.FlagUp,
+				},
+			}, nil
+		},
+		AddrsFunc: func(iface net.Interface) ([]net.Addr, error) {
+			return []net.Addr{
+				&net.IPNet{
+					IP:   net.IPv4(100, 64, 0, 2),
+					Mask: net.CIDRMask(10, 32),
+				},
+			}, nil
+		},
+	}
+
+	oldDefaultNetwork := DefaultNetwork
+	DefaultNetwork = mockNet
+	defer func() {
+		DefaultNetwork = oldDefaultNetwork
+	}()
+
+	ip := "100.64.0.3"
+	_, err := GetInterfaceName(ip)
+	expectedErr := "interface with IP address 100.64.0.3 not found"
+	if err == nil || err.Error() != expectedErr {
+		t.Errorf("Expected error '%s', got %v", expectedErr, err)
+	}
+}
+
+func TestGetInterfaceName_ParseCIDRError(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			if s == TailscaleIP4CIDR {
+				return nil, nil, errors.New("ParseCIDR error")
+			}
+			ip, ipNet, err := net.ParseCIDR(s)
+			return &ip, ipNet, err
+		},
+	}
+
+	oldDefaultNetwork := DefaultNetwork
+	DefaultNetwork = mockNet
+	defer func() {
+		DefaultNetwork = oldDefaultNetwork
+	}()
+
+	ip := "100.64.0.1"
+	_, err := GetInterfaceName(ip)
+	expectedErr := "failed to parse Tailscale IP range: ParseCIDR error"
+	if err == nil || err.Error() != expectedErr {
+		t.Errorf("Expected error '%s', got %v", expectedErr, err)
+	}
+}
+
+func TestGetInterfaceName_InterfacesError(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, err := net.ParseCIDR(s)
+			return &ip, ipNet, err
+		},
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return nil, errors.New("Interfaces error")
+		},
+	}
+
+	oldDefaultNetwork := DefaultNetwork
+	DefaultNetwork = mockNet
+	defer func() {
+		DefaultNetwork = oldDefaultNetwork
+	}()
+
+	ip := "100.64.0.1"
+	_, err := GetInterfaceName(ip)
+	expectedErr := "failed to get network interfaces: Interfaces error"
+	if err == nil || err.Error() != expectedErr {
+		t.Errorf("Expected error '%s', got %v", expectedErr, err)
+	}
+}
+
+func TestGetInterfaceName_AddrsError(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, err := net.ParseCIDR(s)
+			return &ip, ipNet, err
+		},
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return []net.Interface{
+				{
+					Index: 1,
+					Name:  "tailscale0",
+					Flags: net.FlagUp,
+				},
+			}, nil
+		},
+		AddrsFunc: func(iface net.Interface) ([]net.Addr, error) {
+			return nil, errors.New("Addrs error")
+		},
+	}
+
+	oldDefaultNetwork := DefaultNetwork
+	DefaultNetwork = mockNet
+	defer func() {
+		DefaultNetwork = oldDefaultNetwork
+	}()
+
+	ip := "100.64.0.1"
+	_, err := GetInterfaceName(ip)
+	expectedErr := "failed to get interface addresses: Addrs error"
+	if err == nil || err.Error() != expectedErr {
+		t.Errorf("Expected error '%s', got %v", expectedErr, err)
+	}
+}
+
+func TestGetInterfaceName_NonIPNetAddress(t *testing.T) {
+	mockNet := &MockNetwork{
+		ParseCIDRFunc: func(s string) (*net.IP, *net.IPNet, error) {
+			ip, ipNet, err := net.ParseCIDR(s)
+			return &ip, ipNet, err
+		},
+		InterfacesFunc: func() ([]net.Interface, error) {
+			return []net.Interface{
+				{
+					Index: 1,
+					Name:  "tailscale0",
+					Flags: net.FlagUp,
+				},
+			}, nil
+		},
+		AddrsFunc: func(iface net.Interface) ([]net.Addr, error) {
+			return []net.Addr{&MockAddr{}}, nil
+		},
+	}
+
+	oldDefaultNetwork := DefaultNetwork
+	DefaultNetwork = mockNet
+	defer func() {
+		DefaultNetwork = oldDefaultNetwork
+	}()
+
+	ip := "100.64.0.1"
+	_, err := GetInterfaceName(ip)
+	expectedErr := "interface with IP address 100.64.0.1 not found"
+	if err == nil || err.Error() != expectedErr {
+		t.Errorf("Expected error '%s', got %v", expectedErr, err)
+	}
 }


### PR DESCRIPTION
These changes add the ability to get the interface name of an IP address, as long as the IP address is in the Tailscale IPv4 or IPv6 ranges.