### PR TITLE
Resolve incorrect use of pointers with net.IP

### DIFF
--- a/tailutils.go
+++ b/tailutils.go
@@ -13,7 +13,7 @@ var (
 // Network is an interface that abstracts the network operations used in tailutils.
 type Network interface {
 	ParseCIDR(s string) (*net.IPNet, error)
-	ParseIP(s string) (*net.IP, error)
+	ParseIP(s string) (net.IP, error)
 	Interfaces() ([]net.Interface, error)
 	Addrs(iface net.Interface) ([]net.Addr, error)
 }
@@ -26,9 +26,9 @@ func (rn RealNetwork) ParseCIDR(s string) (*net.IPNet, error) {
 	return ipNet, err
 }
 
-func (rn RealNetwork) ParseIP(s string) (*net.IP, error) {
+func (rn RealNetwork) ParseIP(s string) (net.IP, error) {
 	ip := net.ParseIP(s)
-	return &ip, nil
+	return ip, nil
 }
 
 func (rn RealNetwork) Interfaces() ([]net.Interface, error) {

--- a/tailutils_test.go
+++ b/tailutils_test.go
@@ -10,7 +10,7 @@ import (
 // MockNetwork is a mock implementation of the Network interface for testing purposes.
 type MockNetwork struct {
 	ParseCIDRFunc  func(s string) (*net.IPNet, error)
-	ParseIPFunc    func(s string) (*net.IP, error)
+	ParseIPFunc    func(s string) (net.IP, error)
 	InterfacesFunc func() ([]net.Interface, error)
 	AddrsFunc      func(iface net.Interface) ([]net.Addr, error)
 }
@@ -19,7 +19,7 @@ func (m *MockNetwork) ParseCIDR(s string) (*net.IPNet, error) {
 	return m.ParseCIDRFunc(s)
 }
 
-func (m *MockNetwork) ParseIP(s string) (*net.IP, error) {
+func (m *MockNetwork) ParseIP(s string) (net.IP, error) {
 	return m.ParseIPFunc(s)
 }
 
@@ -1089,12 +1089,12 @@ func TestRealNetwork_Addrs(t *testing.T) {
 
 func TestParseIPFunc_InMockNetwork(t *testing.T) {
 	mockNet := &MockNetwork{
-		ParseIPFunc: func(s string) (*net.IP, error) {
+		ParseIPFunc: func(s string) (net.IP, error) {
 			ip := net.ParseIP(s)
 			if ip == nil {
 				return nil, errors.New("invalid IP")
 			}
-			return &ip, nil
+			return ip, nil
 		},
 	}
 


### PR DESCRIPTION
In `RealNetwork.ParseIP`, we're returning a pointer to `net.IP`, but `net.IP` is already a slice of bytes (`[]byte`) and is typically used as a value type. 