### PR TITLE
refactor: make RealNetwork and DefaultNetwork unexported

### DIFF
--- a/tailutils.go
+++ b/tailutils.go
@@ -18,15 +18,15 @@ type Network interface {
 	Addrs(iface net.Interface) ([]net.Addr, error)
 }
 
-// RealNetwork is the real implementation of the Network interface using the net package.
-type RealNetwork struct{}
+// realNetwork is the real implementation of the Network interface using the net package.
+type realNetwork struct{}
 
-func (rn RealNetwork) ParseCIDR(s string) (*net.IPNet, error) {
+func (rn realNetwork) ParseCIDR(s string) (*net.IPNet, error) {
 	_, ipNet, err := net.ParseCIDR(s)
 	return ipNet, err
 }
 
-func (rn RealNetwork) ParseIP(s string) (net.IP, error) {
+func (rn realNetwork) ParseIP(s string) (net.IP, error) {
 	ip := net.ParseIP(s)
 	if ip == nil {
 		return nil, fmt.Errorf("invalid IP: %s", s)
@@ -34,25 +34,25 @@ func (rn RealNetwork) ParseIP(s string) (net.IP, error) {
 	return ip, nil
 }
 
-func (rn RealNetwork) Interfaces() ([]net.Interface, error) {
+func (rn realNetwork) Interfaces() ([]net.Interface, error) {
 	return net.Interfaces()
 }
 
-func (rn RealNetwork) Addrs(iface net.Interface) ([]net.Addr, error) {
+func (rn realNetwork) Addrs(iface net.Interface) ([]net.Addr, error) {
 	return iface.Addrs()
 }
 
-// DefaultNetwork is the default implementation used in production.
-var DefaultNetwork Network = RealNetwork{}
+// defaultNetwork is the default implementation used in production.
+var defaultNetwork Network = realNetwork{}
 
 // GetTailscaleIP returns the IP address of the tailscale interface.
 func GetTailscaleIP() (string, error) {
-	return getTailscaleIP(DefaultNetwork, tailscaleIP4CIDR)
+	return getTailscaleIP(defaultNetwork, tailscaleIP4CIDR)
 }
 
 // GetTailscaleIP6 returns the IPv6 address of the Tailscale interface.
 func GetTailscaleIP6() (string, error) {
-	return getTailscaleIP(DefaultNetwork, tailscaleIP6CIDR)
+	return getTailscaleIP(defaultNetwork, tailscaleIP6CIDR)
 }
 
 func getTailscaleIP(netImpl Network, cidr string) (string, error) {
@@ -116,13 +116,13 @@ func getTailscaleIP(netImpl Network, cidr string) (string, error) {
 // HasTailscaleIP returns true if the machine has a Tailscale interface (either IPv4 or IPv6).
 func HasTailscaleIP() (bool, error) {
 	// Check if the machine has a Tailscale IPv4 interface
-	hasIPv4, err := hasTailscaleIP(DefaultNetwork)
+	hasIPv4, err := hasTailscaleIP(defaultNetwork)
 	if err != nil {
 		return false, err
 	}
 
 	// Check if the machine has a Tailscale IPv6 interface
-	hasIPv6, err := hasTailscaleIP6(DefaultNetwork)
+	hasIPv6, err := hasTailscaleIP6(defaultNetwork)
 	if err != nil {
 		return false, err
 	}
@@ -148,7 +148,7 @@ func hasTailscaleIP6(netImpl Network) (bool, error) {
 
 // GetInterfaceName returns the name of the network interface for the given IP address
 func GetInterfaceName(ip string) (string, error) {
-	return getInterfaceName(DefaultNetwork, ip)
+	return getInterfaceName(defaultNetwork, ip)
 }
 
 // getInterfaceName returns the name of the network interface for the given IP address, but

--- a/tailutils_test.go
+++ b/tailutils_test.go
@@ -488,10 +488,10 @@ func TestHasTailscaleIP_BothIPv4IPv6(t *testing.T) {
 		},
 	}
 
-	oldDefaultNetwork := DefaultNetwork
-	DefaultNetwork = mockNet
+	oldDefaultNetwork := defaultNetwork
+	defaultNetwork = mockNet
 	defer func() {
-		DefaultNetwork = oldDefaultNetwork
+		defaultNetwork = oldDefaultNetwork
 	}()
 
 	hasIP, err := HasTailscaleIP()
@@ -531,10 +531,10 @@ func TestHasTailscaleIP_OnlyIP4(t *testing.T) {
 		},
 	}
 
-	oldDefaultNetwork := DefaultNetwork
-	DefaultNetwork = mockNet
+	oldDefaultNetwork := defaultNetwork
+	defaultNetwork = mockNet
 	defer func() {
-		DefaultNetwork = oldDefaultNetwork
+		defaultNetwork = oldDefaultNetwork
 	}()
 
 	hasIP, err := HasTailscaleIP()
@@ -586,10 +586,10 @@ func TestGetInterfaceName_TailscaleIPv4(t *testing.T) {
 		},
 	}
 
-	oldDefaultNetwork := DefaultNetwork
-	DefaultNetwork = mockNet
+	oldDefaultNetwork := defaultNetwork
+	defaultNetwork = mockNet
 	defer func() {
-		DefaultNetwork = oldDefaultNetwork
+		defaultNetwork = oldDefaultNetwork
 	}()
 
 	ifaceName, err := GetInterfaceName("100.64.0.1")
@@ -641,10 +641,10 @@ func TestGetInterfaceName_TailscaleIPv6(t *testing.T) {
 		},
 	}
 
-	oldDefaultNetwork := DefaultNetwork
-	DefaultNetwork = mockNet
+	oldDefaultNetwork := defaultNetwork
+	defaultNetwork = mockNet
 	defer func() {
-		DefaultNetwork = oldDefaultNetwork
+		defaultNetwork = oldDefaultNetwork
 	}()
 
 	ifaceName, err := GetInterfaceName("fd7a:115c:a1e0::1")
@@ -664,10 +664,10 @@ func TestGetInterfaceName_IPNotInTailscaleRange(t *testing.T) {
 		},
 	}
 
-	oldDefaultNetwork := DefaultNetwork
-	DefaultNetwork = mockNet
+	oldDefaultNetwork := defaultNetwork
+	defaultNetwork = mockNet
 	defer func() {
-		DefaultNetwork = oldDefaultNetwork
+		defaultNetwork = oldDefaultNetwork
 	}()
 
 	ip := "192.168.1.10"
@@ -703,10 +703,10 @@ func TestGetInterfaceName_IPNotFound(t *testing.T) {
 		},
 	}
 
-	oldDefaultNetwork := DefaultNetwork
-	DefaultNetwork = mockNet
+	oldDefaultNetwork := defaultNetwork
+	defaultNetwork = mockNet
 	defer func() {
-		DefaultNetwork = oldDefaultNetwork
+		defaultNetwork = oldDefaultNetwork
 	}()
 
 	ip := "100.64.0.3"
@@ -728,10 +728,10 @@ func TestGetInterfaceName_ParseCIDRError(t *testing.T) {
 		},
 	}
 
-	oldDefaultNetwork := DefaultNetwork
-	DefaultNetwork = mockNet
+	oldDefaultNetwork := defaultNetwork
+	defaultNetwork = mockNet
 	defer func() {
-		DefaultNetwork = oldDefaultNetwork
+		defaultNetwork = oldDefaultNetwork
 	}()
 
 	ip := "100.64.0.1"
@@ -753,10 +753,10 @@ func TestGetInterfaceName_ParseCIDR6Error(t *testing.T) {
 		},
 	}
 
-	oldDefaultNetwork := DefaultNetwork
-	DefaultNetwork = mockNet
+	oldDefaultNetwork := defaultNetwork
+	defaultNetwork = mockNet
 	defer func() {
-		DefaultNetwork = oldDefaultNetwork
+		defaultNetwork = oldDefaultNetwork
 	}()
 
 	ip := "100.64.0.1"
@@ -778,10 +778,10 @@ func TestGetInterfaceName_InterfacesError(t *testing.T) {
 		},
 	}
 
-	oldDefaultNetwork := DefaultNetwork
-	DefaultNetwork = mockNet
+	oldDefaultNetwork := defaultNetwork
+	defaultNetwork = mockNet
 	defer func() {
-		DefaultNetwork = oldDefaultNetwork
+		defaultNetwork = oldDefaultNetwork
 	}()
 
 	ip := "100.64.0.1"
@@ -812,10 +812,10 @@ func TestGetInterfaceName_AddrsError(t *testing.T) {
 		},
 	}
 
-	oldDefaultNetwork := DefaultNetwork
-	DefaultNetwork = mockNet
+	oldDefaultNetwork := defaultNetwork
+	defaultNetwork = mockNet
 	defer func() {
-		DefaultNetwork = oldDefaultNetwork
+		defaultNetwork = oldDefaultNetwork
 	}()
 
 	ip := "100.64.0.1"
@@ -846,10 +846,10 @@ func TestGetInterfaceName_NonIPNetAddress(t *testing.T) {
 		},
 	}
 
-	oldDefaultNetwork := DefaultNetwork
-	DefaultNetwork = mockNet
+	oldDefaultNetwork := defaultNetwork
+	defaultNetwork = mockNet
 	defer func() {
-		DefaultNetwork = oldDefaultNetwork
+		defaultNetwork = oldDefaultNetwork
 	}()
 
 	ip := "100.64.0.1"
@@ -861,9 +861,9 @@ func TestGetInterfaceName_NonIPNetAddress(t *testing.T) {
 }
 
 func TestGetTailscaleIP6_DirectInterfaceFail(t *testing.T) {
-	// Save the original DefaultNetwork and restore it after the test
-	originalNetwork := DefaultNetwork
-	defer func() { DefaultNetwork = originalNetwork }()
+	// Save the original defaultNetwork and restore it after the test
+	originalNetwork := defaultNetwork
+	defer func() { defaultNetwork = originalNetwork }()
 
 	// Create a mock network that won't list properly
 	mockNet := &MockNetwork{
@@ -886,9 +886,9 @@ func TestGetTailscaleIP6_DirectInterfaceFail(t *testing.T) {
 }
 
 func TestGetTailscaleIP6_DirectIfaceDown(t *testing.T) {
-	// Save the original DefaultNetwork and restore it after the test
-	originalNetwork := DefaultNetwork
-	defer func() { DefaultNetwork = originalNetwork }()
+	// Save the original defaultNetwork and restore it after the test
+	originalNetwork := defaultNetwork
+	defer func() { defaultNetwork = originalNetwork }()
 
 	// Create a mock network that for some reason has a tailscale IP yet is labeled as loopback
 	mockNet := &MockNetwork{
@@ -928,9 +928,9 @@ func TestGetTailscaleIP6_DirectIfaceDown(t *testing.T) {
 }
 
 func TestGetTailscaleIP6_DirectInvalidIP(t *testing.T) {
-	// Save the original DefaultNetwork and restore it after the test
-	originalNetwork := DefaultNetwork
-	defer func() { DefaultNetwork = originalNetwork }()
+	// Save the original defaultNetwork and restore it after the test
+	originalNetwork := defaultNetwork
+	defer func() { defaultNetwork = originalNetwork }()
 
 	// Create a mock network that will fail to get the interface IP
 	mockNet := &MockNetwork{
@@ -994,9 +994,9 @@ func TestGetTailscaleIP6_NonIPNetAddress(t *testing.T) {
 }
 
 func TestGetTailscaleIP_Public(t *testing.T) {
-	// Save the original DefaultNetwork and restore it after the test
-	originalNetwork := DefaultNetwork
-	defer func() { DefaultNetwork = originalNetwork }()
+	// Save the original defaultNetwork and restore it after the test
+	originalNetwork := defaultNetwork
+	defer func() { defaultNetwork = originalNetwork }()
 
 	mockNet := &MockNetwork{
 		ParseCIDRFunc: func(s string) (*net.IPNet, error) {
@@ -1025,7 +1025,7 @@ func TestGetTailscaleIP_Public(t *testing.T) {
 		},
 	}
 
-	DefaultNetwork = mockNet
+	defaultNetwork = mockNet
 
 	ip, err := GetTailscaleIP()
 	if err != nil {
@@ -1038,9 +1038,9 @@ func TestGetTailscaleIP_Public(t *testing.T) {
 }
 
 func TestGetTailscaleIP6_Public(t *testing.T) {
-	// Save the original DefaultNetwork and restore it after the test
-	originalNetwork := DefaultNetwork
-	defer func() { DefaultNetwork = originalNetwork }()
+	// Save the original defaultNetwork and restore it after the test
+	originalNetwork := defaultNetwork
+	defer func() { defaultNetwork = originalNetwork }()
 
 	mockNet := &MockNetwork{
 		ParseCIDRFunc: func(s string) (*net.IPNet, error) {
@@ -1069,7 +1069,7 @@ func TestGetTailscaleIP6_Public(t *testing.T) {
 		},
 	}
 
-	DefaultNetwork = mockNet
+	defaultNetwork = mockNet
 
 	ip, err := GetTailscaleIP6()
 	if err != nil {
@@ -1082,9 +1082,9 @@ func TestGetTailscaleIP6_Public(t *testing.T) {
 }
 
 func TestGetTailscaleIP6_Errors(t *testing.T) {
-	// Save the original DefaultNetwork and restore it after the test
-	originalNetwork := DefaultNetwork
-	defer func() { DefaultNetwork = originalNetwork }()
+	// Save the original defaultNetwork and restore it after the test
+	originalNetwork := defaultNetwork
+	defer func() { defaultNetwork = originalNetwork }()
 
 	mockNet := &MockNetwork{
 		ParseCIDRFunc: func(s string) (*net.IPNet, error) {
@@ -1106,7 +1106,7 @@ func TestGetTailscaleIP6_Errors(t *testing.T) {
 		},
 	}
 
-	DefaultNetwork = mockNet
+	defaultNetwork = mockNet
 
 	_, err := GetTailscaleIP6()
 	expectedErr := "tailscale interface not found"
@@ -1116,9 +1116,9 @@ func TestGetTailscaleIP6_Errors(t *testing.T) {
 }
 
 func TestHasTailscaleIP_Public(t *testing.T) {
-	// Save the original DefaultNetwork and restore it after the test
-	originalNetwork := DefaultNetwork
-	defer func() { DefaultNetwork = originalNetwork }()
+	// Save the original defaultNetwork and restore it after the test
+	originalNetwork := defaultNetwork
+	defer func() { defaultNetwork = originalNetwork }()
 
 	mockNet := &MockNetwork{
 		ParseCIDRFunc: func(s string) (*net.IPNet, error) {
@@ -1150,7 +1150,7 @@ func TestHasTailscaleIP_Public(t *testing.T) {
 		},
 	}
 
-	DefaultNetwork = mockNet
+	defaultNetwork = mockNet
 
 	hasIP, err := HasTailscaleIP()
 	if err != nil {
@@ -1162,9 +1162,9 @@ func TestHasTailscaleIP_Public(t *testing.T) {
 }
 
 func TestHasTailscaleIP_NoIPs(t *testing.T) {
-	// Save the original DefaultNetwork and restore it after the test
-	originalNetwork := DefaultNetwork
-	defer func() { DefaultNetwork = originalNetwork }()
+	// Save the original defaultNetwork and restore it after the test
+	originalNetwork := defaultNetwork
+	defer func() { defaultNetwork = originalNetwork }()
 
 	mockNet := &MockNetwork{
 		ParseCIDRFunc: func(s string) (*net.IPNet, error) {
@@ -1176,7 +1176,7 @@ func TestHasTailscaleIP_NoIPs(t *testing.T) {
 		},
 	}
 
-	DefaultNetwork = mockNet
+	defaultNetwork = mockNet
 
 	hasIP, err := HasTailscaleIP()
 	if err == nil {
@@ -1188,7 +1188,7 @@ func TestHasTailscaleIP_NoIPs(t *testing.T) {
 }
 
 func TestRealNetwork_ParseCIDR(t *testing.T) {
-	rn := &RealNetwork{}
+	rn := &realNetwork{}
 	ipNet, err := rn.ParseCIDR("192.168.1.0/24")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
@@ -1203,7 +1203,7 @@ func TestRealNetwork_ParseCIDR(t *testing.T) {
 }
 
 func TestRealNetwork_ParseIP(t *testing.T) {
-	rn := &RealNetwork{}
+	rn := &realNetwork{}
 	ip, err := rn.ParseIP("192.168.1.1")
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
@@ -1215,7 +1215,7 @@ func TestRealNetwork_ParseIP(t *testing.T) {
 }
 
 func TestRealNetwork_ParseIPInvalidIP(t *testing.T) {
-	rn := &RealNetwork{}
+	rn := &realNetwork{}
 	_, err := rn.ParseIP("192.168.1")
 	if err == nil {
 		t.Errorf("Expected error, got nil")
@@ -1223,7 +1223,7 @@ func TestRealNetwork_ParseIPInvalidIP(t *testing.T) {
 }
 
 func TestRealNetwork_Interfaces(t *testing.T) {
-	rn := &RealNetwork{}
+	rn := &realNetwork{}
 	_, err := rn.Interfaces()
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)
@@ -1232,7 +1232,7 @@ func TestRealNetwork_Interfaces(t *testing.T) {
 }
 
 func TestRealNetwork_Addrs(t *testing.T) {
-	rn := &RealNetwork{}
+	rn := &realNetwork{}
 	ifaces, err := rn.Interfaces()
 	if err != nil {
 		t.Errorf("Expected no error, got %v", err)


### PR DESCRIPTION
- Rename `RealNetwork` to `realNetwork` to adhere to Go's unexported naming conventions.
- Rename `DefaultNetwork` to `defaultNetwork` to encapsulate the default network implementation.
- Update all references in `tailutils.go` and `tailutils_test.go` to use the new unexported names.
- Adjust test cases to accommodate the renamed `realNetwork` and `defaultNetwork`.

This refactoring enhances encapsulation by restricting the visibility of network implementation details.